### PR TITLE
update some packages, #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!CAUTION]
+> The following packages are currently out of date.  
+>  
+>  @11ty/eleventy   ^2.0.1  →  ^3.0.0  
+>  @picocss/pico   ^1.5.13  →  ^2.0.6  
+>  gulp             ^4.0.2  →  ^5.0.0  
+>  
+> The currently known bug is that when Gulp is updated to the latest version, Gulp-webp is unable to properly convert to webp or copy png.  
+> Also, when compiling Sass/SCSS, a lot of warnings will appear.
+
+
 <img src="./source/images/screenshot..project2501-v3-dark..thumb.png" width="300">&nbsp;&nbsp;<img src="./source/images/screenshot..project2501-v3-light..thumb.png" width="300">
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/abe8230e-48f9-4ce9-8513-4e0541f64d21/deploy-status)](https://app.netlify.com/sites/project2501/deploys)

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
     "@11ty/eleventy-plugin-directory-output": "^1.0.1",
-    "@fortawesome/fontawesome-free": "^6.5.1",
-    "@picocss/pico": "^1.5.10",
-    "bootstrap": "^5.3.2",
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@picocss/pico": "^1.5.13",
+    "bootstrap": "^5.3.3",
     "cross-env": "^7.0.3",
     "gulp": "^4.0.2",
     "gulp-dart-sass": "^1.1.0",
@@ -43,11 +43,11 @@
     "gulp-terser": "^2.1.0",
     "gulp-webp": "^5.0.0",
     "html-minifier": "^4.0.0",
-    "markdown-it": "^14.0.0",
+    "markdown-it": "^14.1.0",
     "markdown-it-deflist": "^3.0.0",
-    "npm-check-updates": "^16.14.11",
+    "npm-check-updates": "^17.1.15",
     "npm-run-all": "^4.1.5",
-    "rimraf": "^5.0.5",
-    "serve": "^14.2.1"
+    "rimraf": "^6.0.1",
+    "serve": "^14.2.4"
   }
 }


### PR DESCRIPTION
The following packages are currently out of date.  

```
@11ty/eleventy   ^2.0.1  →  ^3.0.0
@picocss/pico   ^1.5.13  →  ^2.0.6
gulp             ^4.0.2  →  ^5.0.0
```

The currently known bug is that when Gulp is updated to the latest version, Gulp-webp is unable to properly convert to webp or copy png.  
Also, when compiling Sass/SCSS, a lot of warnings will appear.

